### PR TITLE
Add 'lng' to list of acceptable longitude column names

### DIFF
--- a/src/cell/visualizer.js
+++ b/src/cell/visualizer.js
@@ -165,7 +165,7 @@ class MapVisualizer extends React.Component {
 
   static test(result){
     return result.columns.some(k => ['lat', 'latitude', 'lattitude'].includes(k.toLowerCase())) &&
-           result.columns.some(k => ['lon', 'longitude', 'long'].includes(k.toLowerCase()))
+           result.columns.some(k => ['lon', 'longitude', 'long', 'lng'].includes(k.toLowerCase()))
   }
 
   state = { loaded: false }
@@ -195,7 +195,7 @@ class MapVisualizer extends React.Component {
     let { result, view } = this.props;
 
     const latName = result.columns.find(k => ['lat', 'latitude', 'lattitude'].includes(k.toLowerCase()))
-    const lonName = result.columns.find(k => ['lon', 'longitude', 'long'].includes(k.toLowerCase()))
+    const lonName = result.columns.find(k => ['lon', 'longitude', 'long', 'lng'].includes(k.toLowerCase()))
 
     function posFromDatum(datum){
       let lat = datum[latName] || 0;


### PR DESCRIPTION
Awesome app!

I use `lng` for my longitude column names (as somewhat suggested by [Google](https://developers.google.com/maps/documentation/javascript/reference). This PR adds support for those column names to be detected as GPS coordinates to display the map notebook option.