### PR TITLE
pin blueprint version (fixes #39)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "dist": "yarn build && electron-builder"
   },
   "dependencies": {
-    "@blueprintjs/core": "^1.22.0",
-    "@blueprintjs/labs": "^0.5.0",
-    "@blueprintjs/table": "^1.19.0",
+    "@blueprintjs/core": "~1.22.0",
+    "@blueprintjs/labs": "~0.5.0",
+    "@blueprintjs/table": "~1.19.0",
     "@skidding/react-codemirror": "^1.0.1",
     "babel-preset-env": "^1.6.0",
     "breadloaf": "^1.3.9",


### PR DESCRIPTION
When using `npm` to install and start, there is an error involving `core_1.Utils.shallowCompareKeys` (see issue #39 for screenshot)

This appears to be a bug with blueprint: https://github.com/palantir/blueprint/issues/1639 .  The current semver `"^1.22.0"` uses the bad version.  The issue does not show up when using `yarn` because the `yarn.lock` specifies an older version.

This commit pins the blueprint dependency versions in `package.json`