### PR TITLE
Add yet another Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node as build-env
+
+ADD ./ /work
+
+WORKDIR /work
+
+RUN npm install
+
+RUN npm run-script build
+
+FROM nginx:alpine
+
+COPY --from=build-env /work/bundle/* /usr/share/nginx/html/


### PR DESCRIPTION
Dockerfile on the former PR #10 seems to be a little fat.
That is because the image includes node_modules, PhantomJS binary, not-used node.js tools. 

In addition, scripts builded and bundled at the image starts, so that means slow startups.

Therefore, this PR is aim to get the image smaller.
#10 's image size is over 1GB however mine is  only 22MB.