### PR TITLE
websocket connection fix for remote docker deployments

### DIFF
--- a/src/db/bridge.js
+++ b/src/db/bridge.js
@@ -10,7 +10,6 @@ import * as U from '../state/update'
 import { UnmountClosed } from 'react-collapse'
 
 const RETRY_INTERVAL = 1000
-const BRIDGE_URL = 'ws://localhost:14645'
 
 let clientConnectorSocket = null
 let checkConnectorInterval
@@ -23,7 +22,7 @@ var bridgeAlive = true
 
 function tryOpenBridge() {
     try {
-        clientConnectorSocket = new WebSocket(BRIDGE_URL)
+        clientConnectorSocket = new WebSocket("ws://" + window.location.hostname + ":14645");
     } catch (err) {
         State.apply('connect', 'bridge_status', U.replace('mixed_fail'))
     }


### PR DESCRIPTION
websocket connection to data bridge was hard coded to localhost

fix is to take the hostname from the site location, so that it can be run up on more than just localhost e.g. docker toolbox or other remote deployment

Should fix #53 #60 #61 #66