### PR TITLE
Fixed typo: "credentails" in carto.js should read "credentials"

### DIFF
--- a/src/db/carto.js
+++ b/src/db/carto.js
@@ -43,7 +43,7 @@ export class Configure extends React.Component {
         }
 
         // let credentials = (config.carto && config.carto.credentials) || {}
-        let credentials = (config.credentials && config.credentails.carto) || {}
+        let credentials = (config.credentials && config.credentials.carto) || {}
 
         const Field = (type, icon, className = '') => (
             <div className="pt-input-group">


### PR DESCRIPTION
This typo causes a crash in development environments that cannot be recovered from without deleting autosave data if carto is selected from the connection menu.