### PR TITLE
Add support for empy cells in MySQL tables

### DIFF
--- a/src/db/mysql.js
+++ b/src/db/mysql.js
@@ -250,6 +250,7 @@ async function disconnectDB() {
 
 export function escapeValue(val) {
     if (!isNaN(val)) return '' + val
+    if (val === undefined) return "''"
     return "'" + (val + '').replace(/'/g, "''") + "'"
 }
 


### PR DESCRIPTION
Currently, having empty columns (or `""`) in a MySQL table will break inline editing, since it will try select based on equality to an unescaped empty string, such as `SELECT COUNT(*) FROM table WHERE column =`.

This bug may occur in other databases as well.